### PR TITLE
デプロイエラー対応

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -15,6 +15,10 @@ COPY ./ /var/www/html/
 RUN php composer.phar install --no-dev
 RUN chmod -R a+w storage/ bootstrap/cache
 
+RUN chmod 777 webpack.mix.js
+RUN chmod 777 -R node_modules
+RUN chmod 777 -R public
+
 RUN npm install
 RUN npm run production
 


### PR DESCRIPTION
## 詳細
コンソールからブランチ指定ではデプロイできるが、Circle CIからのpush契機では`permission denied`が発生する。
https://app.circleci.com/pipelines/github/shinjiezumi/laradock/91/workflows/eb5fa43a-a89a-4e70-bfa1-d7f81d7c4015/jobs/130